### PR TITLE
[Big Fish] Fixed issue with deprecated package.

### DIFF
--- a/bigfish/segmentation/nuc_segmentation.py
+++ b/bigfish/segmentation/nuc_segmentation.py
@@ -13,7 +13,7 @@ import bigfish.stack as stack
 from .postprocess import label_instances
 from .postprocess import clean_segmentation
 
-from skimage.morphology.selem import disk
+from skimage.morphology import disk
 from skimage.morphology import reconstruction
 
 


### PR DESCRIPTION
Hi guys,

disk from skimage.morphology.selem has moved to skimage.morphology.

I've fixed this issue which allows the examples to be run again.

Hope there are still some maintainers out there :)

Best regards,
Stefan